### PR TITLE
Create function for unstable notification, used in UberBuild

### DIFF
--- a/vars/sendSlackBuildUnstableNotification_custom.groovy
+++ b/vars/sendSlackBuildUnstableNotification_custom.groovy
@@ -1,0 +1,10 @@
+
+def call(channel, projectName, buildVersion, committerToSlackNameLookup, customLines) {
+    def scmInfo = new com.falldamagestudio.SCMInfo(this)
+
+    def formatSlackNotification = new com.falldamagestudio.FormatSlackNotification(this)
+    def messages = formatSlackNotification.getSuccessMessages_custom(projectName, buildVersion, scmInfo.getPeopleToInformAboutSuccessfulBuild(), committerToSlackNameLookup, customLines, scmInfo.getChangeLogs())
+
+    def sendSlackNotification = new com.falldamagestudio.SendSlackNotification(this)
+    sendSlackNotification.sendAsMultipleMessages(channel, 'warning', messages)
+}


### PR DESCRIPTION
I'm planning to use that function in UberBuild script, as an **unstable** post variant.
Should be quite similar to **success** version, at least for now